### PR TITLE
 Fix Nginx Proxy Pass Configuration for FastAPI Application

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -6,7 +6,7 @@ server {
     server_name localhost;
 
     location / {
-        proxy_pass http://fastapi-app:8000;
+        proxy_pass https://fastapi-app-book-store-app.onrender.com/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
Description: This pull request addresses a bug where the Nginx proxy pass was incorrectly configured for the FastAPI application. The proxy pass URL was set with a container name instead of the correct URL, leading to issues with routing requests.

Changes:
Updated nginx.conf to correctly configure the proxy pass with the correct URL (https://my-url.com).
Ensured that the FastAPI application is correctly routed through Nginx.
Removed the incorrect container name and added the full domain URL.
Issue:
Previously, the Nginx configuration was pointing to the wrong service name in the proxy pass, which caused failed connections to the FastAPI service. This change ensures proper routing between the Nginx reverse proxy and the FastAPI backend.

Testing:
Verified that the FastAPI service is correctly reachable via Nginx.
Tested both HTTP and HTTPS configurations to ensure correct routing.
