### PR TITLE
Fix Nginx Reverse Proxy for Ngrok 

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -3,12 +3,11 @@ server {
     listen [::]:80;
 
 
-    server_name fastapi-app-book-store-app.onrender.com;
-
+    server_name  7619-2c0f-2a80-ac7-8a10-7322-7d02-b57c-e216.ngrok-free.app; 
 
     location / {
-        proxy_pass https://fastapi-app-book-store-app.onrender.com:8000/;
-        proxy_ssl_verify off;
+        proxy_pass http://fastapi-app:8000;
+        proxy_set_header ngrok-skip-browser-warning "true";
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION

**Description:**  
This PR updates the Nginx configuration to correctly forward requests to the FastAPI application when using Ngrok. Previously, the server was still being identified as `uvicorn`, meaning Nginx was not properly proxying requests.  

### **Changes Made:**  
- Updated `nginx.conf` to properly forward requests to FastAPI.  
- Added the `ngrok-skip-browser-warning` header to bypass Ngrok’s security page.  
- Ensured the correct `proxy_pass` target for FastAPI running inside Docker.  
- Verified that Nginx now properly serves requests instead of Uvicorn directly.  

### **Steps to Test:**  
1. Start FastAPI inside a Docker container:  
   ```bash
   docker-compose up -d fastapi
   ```  
2. Start Nginx inside a Docker container:  
   ```bash
   docker-compose up -d nginx
   ```  
3. Run Ngrok to expose Nginx:  
   ```bash
   ngrok http 80
   ```  
4. Visit the Ngrok URL and confirm FastAPI is served through Nginx.  
